### PR TITLE
Add logic to merge from sessionStorage

### DIFF
--- a/src/stateMachine.tsx
+++ b/src/stateMachine.tsx
@@ -17,6 +17,7 @@ import {
   UpdateStoreFunction,
   StoreUpdateFunction,
 } from './types';
+const merge = require('lodash.merge');
 
 let action: ActionName;
 let storageType: Storage =
@@ -68,8 +69,16 @@ export function createStore(
 
   setUpDevTools(isDevMode, storageType, getName, getStore);
 
-  if (result && Object.keys(result).length) return;
-  setStore(data);
+  if (result && Object.keys(result).length) {
+    Object.keys(result).forEach(key => {
+      if (Object.keys(data).includes(key)) {
+        const merged = merge(result, data);
+        setStore(merged);
+      }
+    });
+  } else {
+    setStore(data);
+  }
 }
 
 export function StateMachineProvider<T>(props: T) {


### PR DESCRIPTION
Issue: When there is existing sessionStorage with the same key as what createStore creates state with, it currently overwrites so the original sessionStorage values are lost. 

Solution: find the same key and spread the object.