### PR TITLE
fix: add check for disabled session storage

### DIFF
--- a/src/stateMachine.tsx
+++ b/src/stateMachine.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import storeFactory from './logic/storeFactory';
 import isUndefined from './utils/isUndefined';
+import isSessionStorageAllowed from './utils/isSessionStorageAllowed';
 import { setUpDevTools } from './logic/devTool';
 import StateMachineContext from './StateMachineContext';
 import getSyncStoreData from './logic/getSyncStoreData';
@@ -21,7 +22,7 @@ import {
 
 const isClient = typeof window !== 'undefined';
 const isDevMode: boolean = process.env.NODE_ENV !== 'production';
-let storageType: Storage = isClient
+let storageType: Storage = isClient && isSessionStorageAllowed()
   ? window.sessionStorage
   : {
       getItem: payload => payload,

--- a/src/utils/isSessionStorageAllowed.ts
+++ b/src/utils/isSessionStorageAllowed.ts
@@ -1,0 +1,7 @@
+export default (): boolean => {
+    try {
+      return !!window.sessionStorage
+    } catch (e) {
+      return false
+    }
+  }


### PR DESCRIPTION
Adds a check for window.sessionStorage. If it does not exist or if accessing it creates an exception (like with disabled cookies) it will return false. Otherwise, it will return true.

Feel free to modify if you need @bluebill1049  👍 

closes #57 