### PR TITLE
Fix Typescript example

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ const updateName = (state: GlobalState, payload: { name: string }) => ({
 const YourComponent = () => {
   const { actions, state } = useStateMachine({
     updateName
-  }));
+  });
 
   return (
     <div onClick={() => actions.updateName({ name: 'Kotaro' })}>


### PR DESCRIPTION
One too many parenthesis breaks the compiler. This PR remove the extra paren to fix the issue.