### PR TITLE
fix: Update middlewares only if available

### DIFF
--- a/src/stateMachine.tsx
+++ b/src/stateMachine.tsx
@@ -20,7 +20,7 @@ export function createStore(
 ) {
   options.name && (storeFactory.name = options.name);
   options.storageType && (storeFactory.storageType = options.storageType);
-  storeFactory.updateMiddleWares(options.middleWares);
+  options.middleWares && storeFactory.updateMiddleWares(options.middleWares);
 
   if (process.env.NODE_ENV !== 'production') {
     setUpDevTools(
@@ -61,7 +61,10 @@ function actionTemplate<TCallback extends AnyCallback>(
   };
 }
 
-export function useStateMachine<TCallback extends AnyCallback, TActions extends AnyActions<TCallback>>(
+export function useStateMachine<
+  TCallback extends AnyCallback,
+  TActions extends AnyActions<TCallback>
+>(
   actions?: TActions,
 ): {
   actions: ActionsOutput<TCallback, TActions>;


### PR DESCRIPTION
## Console error

```log
Uncaught TypeError: Cannot read property 'length' of undefined
```

## What I did
Prevent the update of the  `middleWares` if there is not an array in `options` to be used.