### PR TITLE
feature: On Reset, remove LSM storage

### DIFF
--- a/src/logic/devTool.ts
+++ b/src/logic/devTool.ts
@@ -7,12 +7,14 @@ export function setUpDevTools(
 ) {
   if (typeof window === 'undefined') return;
 
+  window.__LSM__ = name;
+
   window.__LSM_NAME__ = name;
 
   window.__LSM_DEBUG__ = (value: string) =>
     storageType.setItem('___LSM_DEBUG__', value);
 
-  window.__LSM_RESET__ = () => storageType.clear();
+  window.__LSM_RESET__ = () => storageType.removeItem(name);
 
   window.__LSM_GET_STORE__ = () => storageType.getItem(name);
 


### PR DESCRIPTION
Currently, the Reset functionality, used in LSM Dev Tools, clears the entire storage LSM is initialised with.
This is an issue when using `localStorage` as  LSM Dev Tools own user configuration and saved states are also cleared on Reset.

This PR sets the Reset functionality to remove only LSM store.
This seems to me also more coherent from the point of view of the UI: the buttons in LSM Dev Tools allow to save, load and reset LSM store – leaving the rest of the browser's storage intact.