### PR TITLE
Upgrading for React 18 with TypeScript

### DIFF
--- a/src/StateMachineContext.tsx
+++ b/src/StateMachineContext.tsx
@@ -2,9 +2,13 @@ import * as React from 'react';
 import storeFactory from './logic/storeFactory';
 import { StateMachineContextValue } from './types';
 
+type PropsChildren = {
+    children?: React.ReactNode
+};
+
 const StateMachineContext = React.createContext<StateMachineContextValue>(undefined as any);
 
-export const StateMachineProvider: React.FC = ({ children }) => {
+export const StateMachineProvider: React.FC<PropsChildren> = ({ children }) => {
   const [state, setState] = React.useState(storeFactory.state);
 
   return (


### PR DESCRIPTION
fixing React type definitionss -> Removal of implicit children

You can run:
npx types-react-codemod preset-18 ./src